### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ dataset = fo.load_dataset("my_dataset")
 fob.compute_similarity(
     dataset,
     brain_key="my_brain_key",
-    model_name="clip-vit-base32-torch",
+    model="clip-vit-base32-torch",
     metric="cosine",
     )
 ```


### PR DESCRIPTION
Update `compute_similarity` doc example to specify `model` kwarg instead of `model_name`. As-is running v0.23.4 the resulting index doesn't have `config.supports_prompts=True`.